### PR TITLE
feat: interaction toggle

### DIFF
--- a/src/main/java/dev/igalaxy/voicechatinteraction/VoiceChatInteraction.java
+++ b/src/main/java/dev/igalaxy/voicechatinteraction/VoiceChatInteraction.java
@@ -21,7 +21,7 @@ public final class VoiceChatInteraction extends JavaPlugin {
     public static VoiceChatInteraction INSTANCE;
 
     @Nullable
-    private VoiceChatInteractionPlugin voicechatPlugin;
+    public static VoiceChatInteractionPlugin voicechatPlugin;
 
     @Override
     public void onEnable() {
@@ -34,6 +34,7 @@ public final class VoiceChatInteraction extends JavaPlugin {
         config.addDefault("whisper_interaction", false);
         config.addDefault("sneak_interaction", false);
         config.addDefault("minimum_activation_threshold", -50);
+        config.addDefault("default_interaction_toggle", true);
         config.options().copyDefaults(true);
         saveConfig();
 
@@ -47,6 +48,8 @@ public final class VoiceChatInteraction extends JavaPlugin {
         } else {
             LOGGER.info("Failed to register voicechat_interaction plugin");
         }
+
+        this.getCommand("voicechat_interaction").setExecutor(new VoiceChatInteractionCommand());
     }
 
     @Override

--- a/src/main/java/dev/igalaxy/voicechatinteraction/VoiceChatInteractionCommand.java
+++ b/src/main/java/dev/igalaxy/voicechatinteraction/VoiceChatInteractionCommand.java
@@ -1,0 +1,42 @@
+package dev.igalaxy.voicechatinteraction;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+public class VoiceChatInteractionCommand implements CommandExecutor {
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        try {
+            if (sender instanceof Player) {
+                VoiceChatInteractionPlugin plugin = VoiceChatInteraction.voicechatPlugin;
+                Player player = (Player) sender;
+
+                if (args.length == 0) {
+                    player.sendMessage("/voicechat_interaction toggle [<player>]");
+                    return true;
+                }
+
+                if (args[0].equals("toggle")) {
+                    if (args.length >= 2 && player.hasPermission("voicechat_interaction.toggle.others")) {
+                        Player other = Bukkit.getPlayer(args[1]);
+                        plugin.setInteractionToggle(other, !plugin.getInteractionToggle(other));
+                        player.sendMessage("Interactions toggled to " + plugin.getInteractionToggle(other) + " for " + other.name());
+                        other.sendMessage(player.name() + " toggled your interactions to " + plugin.getInteractionToggle(other));
+                    } else if (player.hasPermission("voicechat_interaction.toggle")) {
+                        plugin.setInteractionToggle(player, !plugin.getInteractionToggle(player));
+                        player.sendMessage("Interactions toggled to " + plugin.getInteractionToggle(player) + " for yourself");
+                    } else {
+                        player.sendMessage("You do not have permission to use that command (voicechat_interaction.toggle)");
+                    }
+                }
+            }
+        } catch(Exception e) {
+            e.printStackTrace();
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/dev/igalaxy/voicechatinteraction/VoiceChatInteractionPlugin.java
+++ b/src/main/java/dev/igalaxy/voicechatinteraction/VoiceChatInteractionPlugin.java
@@ -6,7 +6,10 @@ import de.maxhenkel.voicechat.api.events.MicrophonePacketEvent;
 import de.maxhenkel.voicechat.api.events.VoicechatServerStartedEvent;
 import de.maxhenkel.voicechat.api.opus.OpusDecoder;
 import org.bukkit.GameEvent;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
+import org.bukkit.persistence.PersistentDataContainer;
+import org.bukkit.persistence.PersistentDataType;
 
 import javax.annotation.Nullable;
 import java.util.Objects;
@@ -105,6 +108,24 @@ public class VoiceChatInteractionPlugin implements VoicechatPlugin {
             return true;
         }
         return false;
+    }
+
+    public boolean getInteractionToggle(Player player) {
+        PersistentDataContainer data = player.getPersistentDataContainer();
+        NamespacedKey key = new NamespacedKey(VoiceChatInteraction.INSTANCE, "interaction_toggle");
+
+        if (!data.has(key)) {
+            return VoiceChatInteraction.SERVER_CONFIG.defaultInteractionToggle;
+        } else {
+            return data.get(key, PersistentDataType.BYTE) != 0;
+        }
+    }
+
+    public void setInteractionToggle(Player player, Boolean value) {
+        PersistentDataContainer data = player.getPersistentDataContainer();
+        NamespacedKey key = new NamespacedKey(VoiceChatInteraction.INSTANCE, "interaction_toggle");
+
+        data.set(key, PersistentDataType.BYTE, (byte) (value ? 1 : 0));
     }
 
 }

--- a/src/main/java/dev/igalaxy/voicechatinteraction/config/ServerConfig.java
+++ b/src/main/java/dev/igalaxy/voicechatinteraction/config/ServerConfig.java
@@ -7,11 +7,13 @@ public class ServerConfig {
     public boolean whisperInteraction;
     public boolean sneakInteraction;
     public int minActivationThreshold;
+    public boolean defaultInteractionToggle;
 
     public ServerConfig(FileConfiguration config) {
         groupInteraction = config.getBoolean("group_interaction");
         whisperInteraction = config.getBoolean("whisper_interaction");
         sneakInteraction = config.getBoolean("sneak_interaction");
         minActivationThreshold = config.getInt("minimum_activation_threshold");
+        defaultInteractionToggle = config.getBoolean("default_interaction_toggle");
     }
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -7,3 +7,9 @@ authors: [ "henkelmax", "iGalaxy" ]
 description: Detect voice chat with the sculk sensor
 website: https://github.com/iGalaxyYT/voicechat-interaction-paper
 depend: [ voicechat ]
+commands:
+  voicechat_interaction:
+    description: "Manage Voice Chat Interaction settings"
+    usage: "/voicechat_interaction toggle [<player>]"
+    aliases: [voicechat_interaction]
+    permission: voicechat_interaction


### PR DESCRIPTION
`/voicechat_interaction toggle [<player>]`
Permission: `voicechat_interaction.toggle[.others]`

`default_interaction_toggle` in config.yml
Defaults to true (interactions enabled for every player by default)
To disable interactions for every player by default (updates retroactively if players have not toggled before), set it to false

Closes #4 