### PR TITLE
[16] Voice Interaction Not Activating Shriekers & 1.21.1 Update

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,19 +2,19 @@ import io.papermc.hangarpublishplugin.model.Platforms
 
 plugins {
     `java`
-    id("io.papermc.paperweight.userdev") version "1.5.5"
+    id("io.papermc.paperweight.userdev") version "1.7.1"
     id("xyz.jpenilla.run-paper") version "2.0.1"
     id("com.modrinth.minotaur") version "2.+"
     id("io.papermc.hangar-publish-plugin") version "0.0.5"
 }
 
 group = "dev.igalaxy.voicechatinteraction"
-version = "1.3.1"
+version = "1.3.3"
 description = "Detect voice chat with the sculk sensor"
-val minecraftVersion = "1.20.2"
+val minecraftVersion = "1.21.1"
 
 java {
-    toolchain.languageVersion.set(JavaLanguageVersion.of(17))
+    toolchain.languageVersion.set(JavaLanguageVersion.of(21))
 }
 
 repositories {
@@ -24,8 +24,8 @@ repositories {
 }
 
 dependencies {
-    paperweight.paperDevBundle("1.20.2-R0.1-SNAPSHOT")
-    implementation("de.maxhenkel.voicechat:voicechat-api:2.4.0")
+    paperweight.paperDevBundle("1.21.1-R0.1-SNAPSHOT")
+    implementation("de.maxhenkel.voicechat:voicechat-api:2.5.0")
 }
 
 tasks {
@@ -40,7 +40,7 @@ tasks {
     compileJava {
         options.encoding = Charsets.UTF_8.name()
 
-        options.release.set(17)
+        options.release.set(21)
     }
 
     javadoc {
@@ -62,7 +62,7 @@ tasks {
     }
 }
 
-val versions = listOf("1.20", "1.20.2")
+val versions = listOf("1.20", "1.20.2", "1.20.4", "1.20.6", "1.21.1")
 
 modrinth {
     token.set(System.getenv("MODRINTH_TOKEN"))

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/dev/igalaxy/voicechatinteraction/VoiceChatInteraction.java
+++ b/src/main/java/dev/igalaxy/voicechatinteraction/VoiceChatInteraction.java
@@ -26,7 +26,7 @@ public final class VoiceChatInteraction extends JavaPlugin {
     @Override
     public void onEnable() {
         SERVER = getServer();
-        VOICE_GAME_EVENT = GameEvent.PRIME_FUSE;
+        VOICE_GAME_EVENT = GameEvent.EAT;
         INSTANCE = this;
 
         FileConfiguration config = this.getConfig();

--- a/src/main/java/dev/igalaxy/voicechatinteraction/VoiceChatInteractionPlugin.java
+++ b/src/main/java/dev/igalaxy/voicechatinteraction/VoiceChatInteractionPlugin.java
@@ -96,7 +96,7 @@ public class VoiceChatInteractionPlugin implements VoicechatPlugin {
 
         bukkitPlayer.getServer().getScheduler().runTask(VoiceChatInteraction.INSTANCE, () -> {
             if (activate(player)) {
-                bukkitPlayer.getWorld().sendGameEvent(null, VoiceChatInteraction.VOICE_GAME_EVENT, bukkitPlayer.getLocation().toVector());
+                bukkitPlayer.getWorld().sendGameEvent(bukkitPlayer, VoiceChatInteraction.VOICE_GAME_EVENT, bukkitPlayer.getLocation().toVector());
             }
         });
     }


### PR DESCRIPTION
Problem:

- Currently the plugin needs to get the latest versions of it's dependencies
- #16 

Changes:

- Take on changes from previous contributors
- Fix shrieker not triggering due to null parameter
- Change game event to EAT because I think that makes more sense than PRIME_FUSE

Testing:

- Tested on my own personal 1.21.0 server
- Shrieker activated and spawns warden in survival and creative mode via voice
- Sculk sensors tripped via voice
- Warden interactions verified when in survival mode via voice